### PR TITLE
Enforce request validation for add-to-cart API

### DIFF
--- a/src/main/java/net/vatri/ecommerce/controllers/CartController.java
+++ b/src/main/java/net/vatri/ecommerce/controllers/CartController.java
@@ -1,5 +1,7 @@
 package net.vatri.ecommerce.controllers;
-
+import javax.validation.valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import net.vatri.ecommerce.cart.CartItem;
 import net.vatri.ecommerce.cart.CartService;
 import net.vatri.ecommerce.hateoas.OrderResource;
@@ -36,12 +38,27 @@ public class CartController extends CoreController{
         return cartService.createNewCart();
     }
 
-    @PostMapping("/{id}")
-    public String addProduct(@PathVariable("id") String cartId, @RequestBody CartItem cartItem){
-        cartService.addProduct(cartId, cartItem);
-        return "OK";
+    // @PostMapping("/{id}")
+    // public String addProduct(@PathVariable("id") String cartId, @RequestBody CartItem cartItem){
+    //     cartService.addProduct(cartId, cartItem);
+    //     return "OK";
+    // }
+@PostMapping("/{id}")
+public ResponseEntity<?> addProduct(
+        @PathVariable("id") String cartId,
+        @Valid @RequestBody CartItem cartItem,
+        BindingResult bindingResult) {
+
+    if (bindingResult.hasErrors()) {
+        return ResponseEntity
+                .badRequest()
+                .body(bindingResult.getAllErrors());
     }
 
+    cartService.addProduct(cartId, cartItem);
+    return ResponseEntity.ok().build();
+}
+    
     @GetMapping("/{id}")
     public Set<CartItem> getCartItems(@PathVariable("id") String cartId){
         return cartService.getItems(cartId);


### PR DESCRIPTION
This PR enforces request validation in CartController by applying @Valid on the
request body and handling validation failures using BindingResult.

Previously, validation was configured but not enforced, allowing invalid request
payloads to reach the service layer. This change improves API correctness without
altering existing business logic.
